### PR TITLE
Bug Fix: RunHelp fails when using a custom command creator

### DIFF
--- a/src/Oakton.Testing/ActivatorCommandCreatorTests.cs
+++ b/src/Oakton.Testing/ActivatorCommandCreatorTests.cs
@@ -10,7 +10,7 @@ namespace Oakton.Testing
         public void builds_an_instance_with_no_ctor_parameters()
         {
             var creator = new ActivatorCommandCreator();
-            var instance = creator.Create(typeof (NoParamsCommand));
+            var instance = creator.CreateCommand(typeof (NoParamsCommand));
 
             instance.ShouldBeOfType<NoParamsCommand>();
         }
@@ -20,7 +20,7 @@ namespace Oakton.Testing
         {
             var creator = new ActivatorCommandCreator();
 
-            Assert.Throws<MissingMethodException>(() => creator.Create(typeof (ParamsCommand)));
+            Assert.Throws<MissingMethodException>(() => creator.CreateCommand(typeof (ParamsCommand)));
         }
 
         public class FakeModel

--- a/src/Oakton.Testing/CustomCommandCreatorTests.cs
+++ b/src/Oakton.Testing/CustomCommandCreatorTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Shouldly;
+using Xunit;
+
+namespace Oakton.Testing
+{
+    public class CustomCommandCreatorTests
+    {
+        [Fact]
+        public void command_factory_creates_with_custom_creator()
+        {
+            TestCommandCreator creator = new TestCommandCreator();
+            ICommandFactory factory = new CommandFactory(creator);
+            var executor = CommandExecutor.For(_ =>
+            {
+                _.RegisterCommand<TestCommand>();
+            }, creator);
+
+            executor.Execute("test");
+
+            creator.LastCreatedModel.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void help_displays_with_custom_creator()
+        {
+            TestCommandCreator creator = new TestCommandCreator();
+            CommandFactory factory = new CommandFactory(creator);
+            var executor = CommandExecutor.For(_ =>
+            {
+                _.RegisterCommand<TestCommand>();
+            }, creator);
+
+            executor.Execute("");
+
+            creator.LastCreatedModel.ShouldNotBeNull();
+        }
+
+        private class TestCommand : OaktonCommand<object>
+        {
+            public TestCommand(string message)
+            {
+                Message = message;
+            }
+
+            public string Message { get; }
+
+            public override bool Execute(object input)
+            {
+                return true;
+            }
+        }
+
+        private class TestOptions
+        {
+            public TestOptions(string message)
+            {
+                Message = message;
+            }
+
+            public string Message { get; }
+        }
+
+        private class TestCommandCreator : ICommandCreator
+        {
+            public TestCommand LastCreatedCommand { get; private set; }
+
+            public TestOptions LastCreatedModel { get; private set; }
+
+            public IOaktonCommand CreateCommand(Type commandType)
+            {
+                LastCreatedCommand = new TestCommand("created command");
+                return LastCreatedCommand;
+            }
+
+            public object CreateModel(Type modelType)
+            {
+                LastCreatedModel = new TestOptions("created options");
+                return LastCreatedModel;
+            }
+        }
+    }
+}

--- a/src/Oakton.Testing/InputParserTester.cs
+++ b/src/Oakton.Testing/InputParserTester.cs
@@ -188,8 +188,9 @@ namespace Oakton.Testing
         {
             var queue = new Queue<string>(tokens);
             var graph = new InputCommand().Usages;
+            var creator = new ActivatorCommandCreator();
 
-            return (InputModel) graph.BuildInput(queue);
+            return (InputModel) graph.BuildInput(queue, creator);
         }
 
         [Fact]

--- a/src/Oakton.Testing/can_use_fields_as_arguments_and_flags.cs
+++ b/src/Oakton.Testing/can_use_fields_as_arguments_and_flags.cs
@@ -51,8 +51,9 @@ namespace Oakton.Testing
         {
             var queue = new Queue<string>(tokens);
             var graph = new FieldCommand().Usages;
+            var creator = new ActivatorCommandCreator();
 
-            return (FieldModel)graph.BuildInput(queue);
+            return (FieldModel)graph.BuildInput(queue, creator);
         }
 
         public class FieldModel

--- a/src/Oakton/ActivatorCommandCreator.cs
+++ b/src/Oakton/ActivatorCommandCreator.cs
@@ -5,9 +5,14 @@ namespace Oakton
 {
     public class ActivatorCommandCreator : ICommandCreator
     {
-        public IOaktonCommand Create(Type commandType)
+        public IOaktonCommand CreateCommand(Type commandType)
         {
             return Activator.CreateInstance(commandType).As<IOaktonCommand>();
+        }
+
+        public object CreateModel(Type modelType)
+        {
+            return Activator.CreateInstance(modelType);
         }
     }
 }

--- a/src/Oakton/CommandFactory.cs
+++ b/src/Oakton/CommandFactory.cs
@@ -119,7 +119,7 @@ namespace Oakton
             {
 
                 var usageGraph = command.Usages;
-                var input = usageGraph.BuildInput(queue);
+                var input = usageGraph.BuildInput(queue, _commandCreator);
 
                 var run = new CommandRun
                        {
@@ -192,13 +192,13 @@ namespace Oakton
 
         public IEnumerable<IOaktonCommand> BuildAllCommands()
         {
-            return _commandTypes.Select(x => _commandCreator.Create(x));
+            return _commandTypes.Select(x => _commandCreator.CreateCommand(x));
         }
 
 
         public IOaktonCommand Build(string commandName)
         {
-            return _commandCreator.Create(_commandTypes[commandName.ToLower()]);
+            return _commandCreator.CreateCommand(_commandTypes[commandName.ToLower()]);
         }
 
 
@@ -210,7 +210,7 @@ namespace Oakton
 
         public virtual CommandRun HelpRun(Queue<string> queue)
         {
-            var input = (HelpInput) (new HelpCommand().Usages.BuildInput(queue));
+            var input = (HelpInput) (new HelpCommand().Usages.BuildInput(queue, _commandCreator));
             input.CommandTypes = _commandTypes.GetAll();
 
             // Little hokey, but show the detailed help for the default command
@@ -228,7 +228,7 @@ namespace Oakton
                 {
                     input.InvalidCommandName = false;
 
-                    var cmd = Activator.CreateInstance(type).As<IOaktonCommand>();
+                    var cmd = _commandCreator.CreateCommand(type);
                     
                     input.Usage = cmd.Usages;
                 });
@@ -243,7 +243,7 @@ namespace Oakton
         private CommandRun dumpUsagesRun(Queue<string> queue)
         {
             var command = new DumpUsagesCommand();
-            var input = command.Usages.BuildInput(queue).As<DumpUsagesInput>();
+            var input = command.Usages.BuildInput(queue, _commandCreator).As<DumpUsagesInput>();
             input.Commands = this;
             
             return new CommandRun

--- a/src/Oakton/Help/UsageGraph.cs
+++ b/src/Oakton/Help/UsageGraph.cs
@@ -58,9 +58,9 @@ namespace Oakton.Help
             };
         }
 
-        public object BuildInput(Queue<string> tokens)
+        public object BuildInput(Queue<string> tokens, ICommandCreator creator)
         {
-            var model = Activator.CreateInstance(_inputType);
+            var model = creator.CreateModel(_inputType);
             var responding = new List<ITokenHandler>();
 
             while (tokens.Any())

--- a/src/Oakton/ICommandCreator.cs
+++ b/src/Oakton/ICommandCreator.cs
@@ -8,6 +8,7 @@ namespace Oakton
     /// </summary>
     public interface ICommandCreator
     {
-        IOaktonCommand Create(Type commandType);
+        IOaktonCommand CreateCommand(Type commandType);
+        object CreateModel(Type modelType);
     }
 }

--- a/src/OaktonSample/Program.cs
+++ b/src/OaktonSample/Program.cs
@@ -70,9 +70,14 @@ namespace OaktonSample
             _container = container;
         }
 
-        public IOaktonCommand Create(Type commandType)
+        public IOaktonCommand CreateCommand(Type commandType)
         {
             return (IOaktonCommand)_container.GetInstance(commandType);
+        }
+
+        public object CreateModel(Type modelType)
+        {
+            return _container.GetInstance(modelType);
         }
     }
     // ENDSAMPLE


### PR DESCRIPTION
When using a custom `ICommandCreator` to integrate an IOC container, the display of the help for a command fails due to the fact that Model/Option classes may not have parameterless constructors but `Activator.CreateInstance` is being used.

This change uses `ICommandCreator` whenver an object needs to be created so that IOC can participate. All calls to `Activator.CreateInstance` are limited to the `ActivatorCommandCreator`.

Due to the return type of `IOaktonCommand` in the existing `ICommandCreator` method, I added a second method which is used for non-command objects. I am not wild about this design but I didn't want to change `ICommandCreator` into a full blown IOC abstraction.

I am also looking for more feedback and guidance on the unit tests. I am not sure the best way to isolate the scenario of building the help for a command.