### PR TITLE
Async command support

### DIFF
--- a/documentation/documentation/commands.md
+++ b/documentation/documentation/commands.md
@@ -7,7 +7,7 @@ It is perfectly legal to use the same input class across multiple commands
 Oakton commands consist of two parts:
 
 1. A concrete input class that holds all the argument and flag data inputs
-1. A concrete class that inherits from `OaktonCommand<T>` where the "T" is the input class in the first bullet point
+1. A concrete class that inherits from `OaktonCommand<T>` or `OaktonAsyncCommand<T>` where the "T" is the input class in the first bullet point
 
 Looking again at the `NameCommand` from the <[linkto:documentation/getting_started]> topic:
 
@@ -21,6 +21,10 @@ There's only a couple things to note about a command class:
   results
 * The `Usages` syntax in the constructor is explained in a section below
 * The `[Description]` attribute on the class is strictly for the purpose of providing help text and is not mandatory
+
+If you want to make use of `async/await`, you can inherit from `OaktonAsyncCommand<T>` instead.  The only difference is signature of the `Execute()` method:
+
+<[sample:async-command]>
 
 
 ## Argument Usages

--- a/src/MultipleCommands/Program.cs
+++ b/src/MultipleCommands/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Metadata.Ecma335;
+using System.Threading.Tasks;
 using Oakton;
 
 namespace MultipleCommands
@@ -24,10 +25,11 @@ namespace MultipleCommands
     
     // SAMPLE: git-commands
     [Description("Switch branches or restore working tree files")]
-    public class CheckoutCommand : OaktonCommand<CheckoutInput>
+    public class CheckoutCommand : OaktonAsyncCommand<CheckoutInput>
     {
-        public override bool Execute(CheckoutInput input)
+        public override async Task<bool> Execute(CheckoutInput input)
         {
+            await Task.CompletedTask;
             return true;
         }
     }

--- a/src/Oakton/CommandExecutor.cs
+++ b/src/Oakton/CommandExecutor.cs
@@ -147,7 +147,7 @@ namespace Oakton
             return execute(() =>
             {
                 var run = _factory.BuildRun(commandLine);
-                return run.Execute();
+                return run.Execute().Result;
             });
 
         }
@@ -162,7 +162,7 @@ namespace Oakton
             return execute(() =>
             {
                 var run = _factory.BuildRun(readOptions().Concat(args));
-                return run.Execute();
+                return run.Execute().Result;
             });
         }
     }

--- a/src/Oakton/CommandFactory.cs
+++ b/src/Oakton/CommandFactory.cs
@@ -171,7 +171,7 @@ namespace Oakton
         {
             assembly
                 .GetExportedTypes()
-                .Where(x => x.Closes(typeof(OaktonCommand<>)) && x.IsConcrete())
+                .Where(x => (x.Closes(typeof(OaktonCommand<>)) || x.Closes(typeof(OaktonAsyncCommand<>))) && x.IsConcrete())
                 .Each(t => { _commandTypes[CommandNameFor(t)] = t; });
         }
 

--- a/src/Oakton/CommandRun.cs
+++ b/src/Oakton/CommandRun.cs
@@ -1,11 +1,13 @@
-﻿namespace Oakton
+﻿using System.Threading.Tasks;
+
+namespace Oakton
 {
     public class CommandRun
     {
         public IOaktonCommand Command { get; set; }
         public object Input { get; set; }
 
-        public bool Execute()
+        public Task<bool> Execute()
         {
             return Command.Execute(Input);
         }

--- a/src/Oakton/IOaktonCommand.cs
+++ b/src/Oakton/IOaktonCommand.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Threading.Tasks;
 using Oakton.Help;
 
 namespace Oakton
 {
     public interface IOaktonCommand
     {
-        bool Execute(object input);
+        Task<bool> Execute(object input);
         Type InputType { get; }
         UsageGraph Usages { get; }
     }

--- a/src/Oakton/OaktonAsyncCommand.cs
+++ b/src/Oakton/OaktonAsyncCommand.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using Oakton.Help;
+
+namespace Oakton
+{
+    /// <summary>
+    /// Base class for all Oakton commands
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public abstract class OaktonAsyncCommand<T> : IOaktonCommand<T>
+    {
+        protected OaktonAsyncCommand()
+        {
+            Usages = new UsageGraph(GetType());
+        }
+
+        /// <summary>
+        /// If your command has multiple argument usage patterns ala the Git command line, use
+        /// this method to define the valid combinations of arguments and optionally limit the flags that are valid
+        /// for each usage
+        /// </summary>
+        /// <param name="description">The description of this usage to be displayed from the CLI help command</param>
+        /// <returns></returns>
+        public UsageGraph.UsageExpression<T> Usage(string description)
+        {
+            return Usages.AddUsage<T>(description);
+        }
+
+        public UsageGraph Usages { get; }
+
+        public Type InputType => typeof(T);
+
+        Task<bool> IOaktonCommand.Execute(object input)
+        {
+            return Execute((T)input);
+        }
+
+        /// <summary>
+        /// The actual execution of the command. Return "false" to denote failures
+        /// or "true" for successes
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public abstract Task<bool> Execute(T input);
+    }
+}

--- a/src/Oakton/OaktonCommand.cs
+++ b/src/Oakton/OaktonCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Oakton.Help;
 
 namespace Oakton
@@ -30,9 +31,9 @@ namespace Oakton
 
         public Type InputType => typeof (T);
 
-        bool IOaktonCommand.Execute(object input)
+        Task<bool> IOaktonCommand.Execute(object input)
         {
-            return Execute((T)input);
+            return Task.FromResult(Execute((T)input));
         }
 
         /// <summary>

--- a/src/quickstart/Program.cs
+++ b/src/quickstart/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Oakton;
 
 namespace quickstart
@@ -20,15 +21,15 @@ namespace quickstart
     {
         [Description("The name to be printed to the console output")]
         public string Name { get; set; }
-        
+
         [Description("The color of the text. Default is black")]
         public ConsoleColor Color { get; set; } = ConsoleColor.Black;
-        
+
         [Description("Optional title preceeding the name")]
         public string TitleFlag { get; set; }
     }
     // ENDSAMPLE
-    
+
     // SAMPLE: NameCommand
     [Description("Print somebody's name")]
     public class NameCommand : OaktonCommand<NameInput>
@@ -48,7 +49,7 @@ namespace quickstart
             {
                 text = input.TitleFlag + " " + text;
             }
-            
+
             // This is a little helper in Oakton for getting
             // cute with colors in the console output
             ConsoleWriter.Write(input.Color, text);
@@ -73,7 +74,7 @@ namespace quickstart
                 // and in what order they should be expressed
                 // by the user
                 .Arguments(x => x.Name, x => x.Color)
-                
+
                 // Optionally, you can provide a white list of valid
                 // flags in this usage
                 .ValidFlags(x => x.TitleFlag);
@@ -85,7 +86,7 @@ namespace quickstart
             return true;
         }
     }
-    
+
     // SAMPLE: command-alias
     [Description("Say my name differently", Name = "different-name")]
     public class AliasedCommand : OaktonCommand<NameInput>
@@ -96,4 +97,18 @@ namespace quickstart
             throw new NotImplementedException();
         }
     }
+
+    // SAMPLE: async-command
+    public class DoNameThingsCommand : OaktonAsyncCommand<NameInput>
+    {
+        public override async Task<bool> Execute(NameInput input)
+        {
+            ConsoleWriter.Write(input.Color, "Starting...");
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            ConsoleWriter.Write(input.Color, $"Done! Hello {input.Name}");
+            return true;
+        }
+    }
+    // ENDSAMPLE
 }


### PR DESCRIPTION
* Changed commands to be async internally, and `OaktonCommand`'s private implementation of `IOaktonCommand` to use `Task.FromResult(Execute((T)input))`.
* New base class for commands (`OaktonAsyncCommand<T>`).
* Add documentation 😱 
* I didn't add a `CancellationToken` to the method as I couldn't see a clean way of providing a token, and cancelling it on `ctrl+c` usage

Only thing I am not sure on is what version number to set in the `rakefile`, as I changed the `IOakonCommand`'s definition it should be `2.0.0` I guess? Although from a typical user's perspective, `1.4.1` would make sense as people only really inherit `OaktonCommand<T>`.