### PR TITLE
Add support for flags with long form alias only. Rationale: with mult…

### DIFF
--- a/documentation/documentation/flags/index.md
+++ b/documentation/documentation/flags/index.md
@@ -49,6 +49,8 @@ a property named `FirstNameFlag` would be parsed at the command line as either `
 You can of course override the flag alias in either long or short form by using the `[FlagAlias]` attribute as shown in the `CleanInput`
 example above.
 
+Lastly, if only the long form alias is desired, `[FlagAlias]` provides the constructor `FlagAliasAttribute(string longAlias, bool longAliasOnly)`.
+
 Just like <[linkto:documentation/arguments]>, Flags can be any type that Oakton knows how to convert, with a few special types shown in the subsequent sections:
 
 

--- a/src/Oakton.Testing/FlagTester.cs
+++ b/src/Oakton.Testing/FlagTester.cs
@@ -72,6 +72,20 @@ namespace Oakton.Testing
         }
 
         [Fact]
+        public void to_usage_description_for_a_simple_aliased_field_with_longform_only()
+        {
+            forProp(x => x.LongFormAliasFlag).ToUsageDescription().ShouldBe("[--longformaliased <longformalias>]");
+        }
+
+
+        [Fact]
+        public void should_ignore_default_shortform_for_longform_only_alias()
+        {            
+            forProp(x => x.LongFormAliasFlag).Handle(new FlagTarget(), new Queue<string>(new[] { "-l" })).ShouldBe(false);
+        }
+
+
+        [Fact]
         public void to_usage_description_for_a_simple_non_aliased_field()
         {
             forProp(x => x.NameFlag).ToUsageDescription().ShouldBe("[-n, --name <name>]");
@@ -100,6 +114,10 @@ namespace Oakton.Testing
 
         [FlagAlias("aliased", 'a')]
         public string AliasFlag { get; set; }
+
+
+        [FlagAlias("longformaliased", true)]
+        public string LongFormAliasFlag { get; set; }
 
         public IEnumerable<string> HerpDerpFlag { get; set; }
     }

--- a/src/Oakton/FlagAliasAttribute.cs
+++ b/src/Oakton/FlagAliasAttribute.cs
@@ -21,12 +21,20 @@ namespace Oakton
 
         public FlagAliasAttribute(string longAlias)
         {
+            LongAlias = longAlias;            
+        }
+
+        public FlagAliasAttribute(string longAlias, bool longAliasOnly)
+        {
             LongAlias = longAlias;
+            LongAliasOnly = longAliasOnly;
         }
 
         public string LongAlias { get; }
-
+        
 
         public char? OneLetterAlias { get; }
+
+        public bool LongAliasOnly { get; }
     }
 }

--- a/src/Oakton/Parsing/FlagAliases.cs
+++ b/src/Oakton/Parsing/FlagAliases.cs
@@ -5,9 +5,11 @@
         public string LongForm { get; set; }
         public string ShortForm { get; set; }
 
+        public bool LongFormOnly { get; set; }
+
         public bool Matches(string token)
         {
-            if(InputParser.IsShortFlag(token))
+            if(!LongFormOnly && InputParser.IsShortFlag(token))
             {
                 return token == ShortForm;
             }
@@ -19,7 +21,7 @@
 
         public override string ToString()
         {
-            return $"{ShortForm}, {LongForm}";
+            return LongFormOnly ? $"{LongForm}" : $"{ShortForm}, {LongForm}";
         }
     }
 }

--- a/src/Oakton/Parsing/InputParser.cs
+++ b/src/Oakton/Parsing/InputParser.cs
@@ -104,17 +104,20 @@ namespace Oakton.Parsing
             name = splitOnPascalCaseAndAddHyphens(name);
 
             var oneLetterName = name.ToLower()[0];
+            var longFormOnly = false;
 
             member.ForAttribute<FlagAliasAttribute>(att =>
             {
                 name = att.LongAlias ?? name;
                 oneLetterName = att.OneLetterAlias ?? oneLetterName;
+                longFormOnly = att.LongAliasOnly;
             });
 
             return new FlagAliases
                        {
                            ShortForm = (SHORT_FLAG_PREFIX + oneLetterName),
-                           LongForm = LONG_FLAG_PREFIX + name.ToLower()
+                           LongForm = LONG_FLAG_PREFIX + name.ToLower(),
+                           LongFormOnly = longFormOnly
                        };
         }
 


### PR DESCRIPTION
…itude of flags, defining & finding non-overlapping flags can be inconvenient. More advanced commands can be kept without short form. Introduce additional ctor in FlagAliasAttribute to maintain binary compatibility (as opposed to arg with default value).