### PR TITLE
inputParser: support TypeConverters

### DIFF
--- a/src/Oakton/Oakton.csproj
+++ b/src/Oakton/Oakton.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />

--- a/src/Oakton/Parsing/InputParser.cs
+++ b/src/Oakton/Parsing/InputParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -18,7 +19,13 @@ namespace Oakton.Parsing
         private static readonly Regex SHORT_FLAG_REGEX = new Regex("^{0}[^-]+".ToFormat(SHORT_FLAG_PREFIX)); 
         
         private static readonly string FLAG_SUFFIX = "Flag";
-        private static readonly Conversions _converter = new Conversions();
+        private static readonly Conversions _converter;
+
+        static InputParser()
+        {
+            _converter = new Conversions();
+            _converter.RegisterConversionProvider<TypeConverterProvider>();
+        }
 
 
         public static List<ITokenHandler> GetHandlers(Type inputType)
@@ -124,6 +131,18 @@ namespace Oakton.Parsing
         private static string splitOnPascalCaseAndAddHyphens(string name)
         {
             return name.SplitPascalCase().Split(' ').Join("-");
+        }
+    }
+
+    public class TypeConverterProvider : IConversionProvider
+    {
+        public Func<string, object> ConverterFor(Type type)
+        {
+            return value =>
+            {
+                var converter = TypeDescriptor.GetConverter(type);
+                return converter.ConvertFromString(value);
+            };
         }
     }
 }


### PR DESCRIPTION
Adds support for types with a `TypeConverter` specified on them to be used in the input models.
Requires package reference to `System.ComponentModel.TypeConverter` for `netstandard1.3`.

I wasn't sure if this should be added directly to Oakton, or if adding the provider into Baseline directly would be better.