### PR TITLE
Corrects "Change Branch" Flag Sample Naming

### DIFF
--- a/src/MultipleCommands/Program.cs
+++ b/src/MultipleCommands/Program.cs
@@ -64,7 +64,7 @@ namespace MultipleCommands
     public class CheckoutInput
     {
         [FlagAlias("create-branch",'b')]
-        public string c { get; set; }
+        public string CreateBranchFlag { get; set; }
         
         public bool DetachFlag { get; set; }
         


### PR DESCRIPTION
The docs mention that this flag should be named `CreateBranchFlag` (https://jasperfx.github.io/oakton/documentation/flags/), but the sample code shows it as `c`. Since `c` does not fit the naming conventions for being a Flag, I assume the docs are correct in this case.