### PR TITLE
Fix Flag Shortening

### DIFF
--- a/src/Oakton.Testing/FlagTester.cs
+++ b/src/Oakton.Testing/FlagTester.cs
@@ -109,6 +109,12 @@ namespace Oakton.Testing
         {
             forProp(x => x.FlagFlag).ToUsageDescription().ShouldBe("[-f, --flag <flag>]");
         }
+
+        [Fact]
+        public void to_usage_description_for__flag_string()
+        {
+            forProp(x => x.Flag).ToUsageDescription().ShouldBe("[-f, --flag <flag>]");
+        }
     }
 
     public enum FlagEnum
@@ -136,6 +142,8 @@ namespace Oakton.Testing
         public string LagFlag { get; set; }
 
         public string FlagFlag { get; set; }
+
+        public string Flag { get; set; }
     }
 
     // SAMPLE: FileInput

--- a/src/Oakton.Testing/FlagTester.cs
+++ b/src/Oakton.Testing/FlagTester.cs
@@ -97,6 +97,12 @@ namespace Oakton.Testing
         {
             forProp(x => x.EnumFlag).ToUsageDescription().ShouldBe("[-e, --enum red|blue|green]");
         }
+
+        [Fact]
+        public void to_usage_description_for_string_ending_with_flag_letters()
+        {
+            forProp(x => x.LagFlag).ToUsageDescription().ShouldBe("[-l, --lag <lag>]");
+        }
     }
 
     public enum FlagEnum
@@ -120,6 +126,8 @@ namespace Oakton.Testing
         public string LongFormAliasFlag { get; set; }
 
         public IEnumerable<string> HerpDerpFlag { get; set; }
+
+        public string LagFlag { get; set; }
     }
 
     // SAMPLE: FileInput

--- a/src/Oakton.Testing/FlagTester.cs
+++ b/src/Oakton.Testing/FlagTester.cs
@@ -103,6 +103,12 @@ namespace Oakton.Testing
         {
             forProp(x => x.LagFlag).ToUsageDescription().ShouldBe("[-l, --lag <lag>]");
         }
+
+        [Fact]
+        public void to_usage_description_for_flag_flag_string()
+        {
+            forProp(x => x.FlagFlag).ToUsageDescription().ShouldBe("[-f, --flag <flag>]");
+        }
     }
 
     public enum FlagEnum
@@ -128,6 +134,8 @@ namespace Oakton.Testing
         public IEnumerable<string> HerpDerpFlag { get; set; }
 
         public string LagFlag { get; set; }
+
+        public string FlagFlag { get; set; }
     }
 
     // SAMPLE: FileInput

--- a/src/Oakton.Testing/FlagTester.cs
+++ b/src/Oakton.Testing/FlagTester.cs
@@ -111,9 +111,17 @@ namespace Oakton.Testing
         }
 
         [Fact]
-        public void to_usage_description_for__flag_string()
+        public void to_usage_description_for_flag_string()
         {
             forProp(x => x.Flag).ToUsageDescription().ShouldBe("[-f, --flag <flag>]");
+        }
+
+        [Fact]
+        public void to_usage_description_for_enumerable_flag_ending_with_flag_letters()
+        {
+            forArg(x => x.SlagFlag)
+                .ToUsageDescription()
+                .ShouldBe("[-s, --slag [<slag1 slag2 slag3 ...>]]");
         }
     }
 
@@ -144,6 +152,8 @@ namespace Oakton.Testing
         public string FlagFlag { get; set; }
 
         public string Flag { get; set; }
+
+        public IEnumerable<string> SlagFlag { get; set; }
     }
 
     // SAMPLE: FileInput

--- a/src/Oakton.Testing/InputParserTester.cs
+++ b/src/Oakton.Testing/InputParserTester.cs
@@ -381,6 +381,18 @@ namespace Oakton.Testing
         }
 
         [Fact]
+        public void RemoveFlagSuffix_should_remove_suffix()
+        {
+            InputParser.RemoveFlagSuffix("FlagFlag").ShouldBe("Flag");
+        }
+
+        [Fact]
+        public void RemoveFlagSuffix_should_stay_same_if_is_suffix()
+        {
+            InputParser.RemoveFlagSuffix("Flag").ShouldBe("Flag");
+        }
+
+        [Fact]
         public void complex_usage_smoketest()
         {
             new UsageGraph(typeof(InputCommand)).WriteUsages("fubu");

--- a/src/Oakton.Testing/InputParserTester.cs
+++ b/src/Oakton.Testing/InputParserTester.cs
@@ -102,6 +102,20 @@ namespace Oakton.Testing
         }
 
         [Fact]
+        public void get_the_long_flag_name_for_property_named_flag()
+        {
+            var property = ReflectionHelper.GetProperty<InputModel>(x => x.Flag);
+            InputParser.ToFlagAliases(property).LongForm.ShouldBe("--flag");
+        }
+
+        [Fact]
+        public void get_the_short_name_for_property_named_flag()
+        {
+            var property = ReflectionHelper.GetProperty<InputModel>(x => x.Flag);
+            InputParser.ToFlagAliases(property).ShortForm.ShouldBe("-f");
+        }
+
+        [Fact]
         public void get_the_short_flag_name_for_a_property_with_an_alias()
         {
             var property = ReflectionHelper.GetProperty<InputModel>(x => x.AliasedFlag);
@@ -412,7 +426,8 @@ namespace Oakton.Testing
         public string AliasedFlag { get; set; }
         
         public Dictionary<string, string> PropsFlag { get; set; } = new Dictionary<string, string>();
-        
+
+        public string Flag { get; set; }
     }
 
     public class InputCommand : OaktonCommand<InputModel>

--- a/src/Oakton/Parsing/EnumerableFlag.cs
+++ b/src/Oakton/Parsing/EnumerableFlag.cs
@@ -49,8 +49,14 @@ namespace Oakton.Parsing
         {
             var flagAliases = InputParser.ToFlagAliases(_member);
 
-            return "[{0} [<{1}1 {1}2 {1}3 ...>]]".ToFormat(flagAliases, _member.Name.ToLower().TrimEnd('f', 'l', 'a', 'g'));
-            
+            var name = _member.Name.ToLower();
+
+            if (name.EndsWith("flag") && name.Length > 4)
+            {
+                name = name.Substring(0, name.Length - 4);
+            }
+
+            return "[{0} [<{1}1 {1}2 {1}3 ...>]]".ToFormat(flagAliases, name);
         }
     }
 }

--- a/src/Oakton/Parsing/EnumerableFlag.cs
+++ b/src/Oakton/Parsing/EnumerableFlag.cs
@@ -49,13 +49,7 @@ namespace Oakton.Parsing
         {
             var flagAliases = InputParser.ToFlagAliases(_member);
 
-            var name = _member.Name.ToLower();
-
-            if (name.EndsWith("flag") && name.Length > 4)
-            {
-                name = name.Substring(0, name.Length - 4);
-            }
-
+            var name = InputParser.RemoveFlagSuffix(_member.Name).ToLower();
             return "[{0} [<{1}1 {1}2 {1}3 ...>]]".ToFormat(flagAliases, name);
         }
     }

--- a/src/Oakton/Parsing/Flag.cs
+++ b/src/Oakton/Parsing/Flag.cs
@@ -59,7 +59,7 @@ namespace Oakton.Parsing
 
             var name = _member.Name.ToLower();
             
-            if (name.EndsWith("flag"))
+            if (name.EndsWith("flag") && name.Length > 4)
             {
                 name = name.Substring(0, name.Length - 4);
             }

--- a/src/Oakton/Parsing/Flag.cs
+++ b/src/Oakton/Parsing/Flag.cs
@@ -57,8 +57,14 @@ namespace Oakton.Parsing
                 return $"[{flagAliases} {enumValues}]";
             }
 
+            var name = _member.Name.ToLower();
             
-            return $"[{flagAliases} <{_member.Name.ToLower().TrimEnd('f', 'l','a','g')}>]";
+            if (name.EndsWith("flag"))
+            {
+                name = name.Substring(0, name.Length - 4);
+            }
+
+            return $"[{flagAliases} <{name}>]";
         }
     }
 }

--- a/src/Oakton/Parsing/Flag.cs
+++ b/src/Oakton/Parsing/Flag.cs
@@ -57,13 +57,7 @@ namespace Oakton.Parsing
                 return $"[{flagAliases} {enumValues}]";
             }
 
-            var name = _member.Name.ToLower();
-            
-            if (name.EndsWith("flag") && name.Length > 4)
-            {
-                name = name.Substring(0, name.Length - 4);
-            }
-
+            var name = InputParser.RemoveFlagSuffix(_member.Name).ToLower();
             return $"[{flagAliases} <{name}>]";
         }
     }

--- a/src/Oakton/Parsing/InputParser.cs
+++ b/src/Oakton/Parsing/InputParser.cs
@@ -96,7 +96,7 @@ namespace Oakton.Parsing
         public static FlagAliases ToFlagAliases(MemberInfo member)
         {
             var name = member.Name;
-            if (name.EndsWith("Flag"))
+            if (name.EndsWith("Flag") && name.Length > 4)
             {
                 name = name.Substring(0, member.Name.Length - 4);
             }

--- a/src/Oakton/Parsing/InputParser.cs
+++ b/src/Oakton/Parsing/InputParser.cs
@@ -95,12 +95,7 @@ namespace Oakton.Parsing
 
         public static FlagAliases ToFlagAliases(MemberInfo member)
         {
-            var name = member.Name;
-            if (name.EndsWith("Flag") && name.Length > 4)
-            {
-                name = name.Substring(0, member.Name.Length - 4);
-            }
-
+            var name = RemoveFlagSuffix(member.Name);
             name = splitOnPascalCaseAndAddHyphens(name);
 
             var oneLetterName = name.ToLower()[0];
@@ -119,6 +114,21 @@ namespace Oakton.Parsing
                            LongForm = LONG_FLAG_PREFIX + name.ToLower(),
                            LongFormOnly = longFormOnly
                        };
+        }
+
+        public static string RemoveFlagSuffix(string fullFlagName)
+        {
+            var suffixLength = FLAG_SUFFIX.Length;
+            var shouldBeRemoved = fullFlagName.ToLower().EndsWith(FLAG_SUFFIX.ToLower())
+                && fullFlagName.Length > suffixLength;
+            if (shouldBeRemoved)
+            {
+                return fullFlagName.Substring(0, fullFlagName.Length - suffixLength);
+            }
+            else
+            {
+                return fullFlagName;
+            }
         }
 
         private static string splitOnPascalCaseAndAddHyphens(string name)


### PR DESCRIPTION
* Fixes bug in ToUsageDescription which produced invalid outputs like `[-c, --config <confi>] -> File to load settings from` (missing letter `g`)
* Flag property named Flag no longer throws exception (stays as `flag`)