### PR TITLE
Add netstandard2.0 to Oakton.AspNetCore

### DIFF
--- a/src/Oakton.AspNetCore/CommandLineHostingExtensions.cs
+++ b/src/Oakton.AspNetCore/CommandLineHostingExtensions.cs
@@ -3,11 +3,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Baseline;
 using Oakton.AspNetCore.Internal;
-#if NETSTANDARD2_0
-using Microsoft.AspNetCore.Hosting;
-#else
 using Microsoft.Extensions.Hosting;
-#endif
 
 
 namespace Oakton.AspNetCore

--- a/src/Oakton.AspNetCore/NetCoreInput.cs
+++ b/src/Oakton.AspNetCore/NetCoreInput.cs
@@ -3,11 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Baseline;
-#if NETSTANDARD2_0
-using Microsoft.AspNetCore.Hosting;
-#else
 using Microsoft.Extensions.Hosting;
-#endif
 using Microsoft.Extensions.Configuration;
 
 using Microsoft.Extensions.Logging;
@@ -33,11 +29,7 @@ namespace Oakton.AspNetCore
 
         [IgnoreOnCommandLine] public Assembly ApplicationAssembly { get; set; }
 
-#if NETSTANDARD2_0
-        public IWebHost BuildHost()
-#else
         public IHost BuildHost() 
-#endif
         {
             // SAMPLE: what-the-cli-is-doing
 

--- a/src/Oakton.AspNetCore/Oakton.AspNetCore.csproj
+++ b/src/Oakton.AspNetCore/Oakton.AspNetCore.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;netstandard2.0</TargetFrameworks>
 
         <Description>Command Line Parsing and Execution</Description>
         <AssemblyTitle>Oakton.AspNetCore</AssemblyTitle>
@@ -24,8 +24,12 @@
       <ProjectReference Include="..\Oakton\Oakton.csproj" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.0.0,4.0.0)" />
+    </ItemGroup>
+  
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">

--- a/src/Oakton.AspNetCore/RunCommand.cs
+++ b/src/Oakton.AspNetCore/RunCommand.cs
@@ -3,13 +3,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading;
-#if NETSTANDARD2_0
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-#else
+
 using Microsoft.Extensions.Hosting;
-#endif
 using Microsoft.Extensions.DependencyInjection;
 
 using Oakton.AspNetCore.Environment;
@@ -25,11 +20,7 @@ namespace Oakton.AspNetCore
     [Description("Runs the configured AspNetCore application")]
     public class RunCommand : OaktonCommand<RunInput>
     {
-#if NETSTANDARD2_0
-        public IWebHost Host { get; private set; }
-        #else
         public IHost Host { get; private set; }
-#endif
 
         public ManualResetEventSlim Reset { get; } = new ManualResetEventSlim();
         public ManualResetEventSlim Started { get; } = new ManualResetEventSlim();
@@ -75,22 +66,10 @@ namespace Oakton.AspNetCore
                 //Console.WriteLine("Running all environment checks...");
                 //host.ExecuteAllEnvironmentChecks();
 
-#if NETSTANDARD2_0
-                var service = Host.Services.GetService<IHostingEnvironment>();
-                #else
                 var service = Host.Services.GetService<IHostEnvironment>();
-#endif
 
                 Console.WriteLine("Hosting environment: " + service.EnvironmentName);
                 Console.WriteLine("Content root path: " + service.ContentRootPath);
-#if NETSTANDARD2_0
-                ICollection<string> addresses = Host.ServerFeatures.Get<IServerAddressesFeature>()?.Addresses;
-                if (addresses != null)
-                {
-                    foreach (string str in addresses)
-                        Console.WriteLine("Now listening on: " + str);
-                }
-#endif
                 
                 if (!string.IsNullOrEmpty(shutdownMessage))
                     Console.WriteLine(shutdownMessage);


### PR DESCRIPTION
This change is included in a set of changes with the intent of adding netstandard2.0 back to Jasper in the newest versions. The big requirement is the use of IHostBuilder in CommandLineHostingExtensions.RunOaktonCommands (instead of IHostBuilder).

Remove preprocessor redirects for netstandard2.0 that attempt to use Microsoft.AspNetCore.Hosting instead of Microsoft.Extensions.Hosting. Microsoft.Extensions.Hosting works with netstandard2.0. One other part where this is removed is in RunCommand, where the old netstandard2.0 libraries were still using IWebHost, as well as writing some console output. This has been removed to sync it with the netcore3.1 and net5.0 versions.

Add netstandard2.0 framework target to Oakton.AspNetCore.

Add Microsoft.Extensions.Hosting conditionally to netstandard2.0 target framework type. The version used is identical to netcoreapp3.1, so these could possibly be merged in the future.