### PR TITLE
(bugfix) Avoid throwing exception from ConfigurationPreview when configuration contains "["

### DIFF
--- a/src/Oakton/Descriptions/ConfigurationPreview.cs
+++ b/src/Oakton/Descriptions/ConfigurationPreview.cs
@@ -48,7 +48,7 @@ namespace Oakton.Descriptions
                     IHasTreeNodes parent = node;
                     if (valuesAndProviders.Count == 0)
                     {
-                        parent = node.AddNode($"[blue]{child.Key}[/]");
+                        parent = node.AddNode($"[blue]{child.Key.EscapeMarkup()}[/]");
                     }
                     else
                     {
@@ -62,7 +62,7 @@ namespace Oakton.Descriptions
                                 .AddColumn("Value")
                                 .AddColumn("Provider")
                                 .HideHeaders()
-                                .AddRow($"[yellow]{child.Key}[/]", finalValue.Value, $@"([grey]{finalValue.Provider}[/])")
+                                .AddRow($"[yellow]{child.Key.EscapeMarkup()}[/]", finalValue.Value.EscapeMarkup(), $@"([grey]{finalValue.Provider.ToString().EscapeMarkup()}[/])")
                         );
 
                         // Loop through the remaining (overridden) values
@@ -76,7 +76,7 @@ namespace Oakton.Descriptions
                                     .AddColumn("Value")
                                     .AddColumn("Provider")
                                     .HideHeaders()
-                                    .AddRow($"[strikethrough]{overriddenValue.Value}[/]", $@"([grey]{overriddenValue.Provider}[/])")
+                                    .AddRow($"[strikethrough]{overriddenValue.Value.EscapeMarkup()}[/]", $@"([grey]{overriddenValue.Provider.ToString().EscapeMarkup()}[/])")
                             );
                         }
                     }

--- a/src/Oakton/Oakton.csproj
+++ b/src/Oakton/Oakton.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Command Line Parsing and Execution</Description>
     <AssemblyTitle>Oakton</AssemblyTitle>
-    <Version>4.6.1</Version>
+    <Version>4.6.2</Version>
     <Authors>Jeremy D. Miller</Authors>
     <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>

--- a/src/Tests/CommandExecutorTester.cs
+++ b/src/Tests/CommandExecutorTester.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Tests
 {
+    [Collection("SetConsoleOutput")]
     public class CommandExecutorTester
     {
         private readonly StringWriter theOutput = new StringWriter();

--- a/src/Tests/Descriptions/ConfigurationPreviewTests.cs
+++ b/src/Tests/Descriptions/ConfigurationPreviewTests.cs
@@ -1,0 +1,58 @@
+﻿using Baseline;
+using Lamar.IoC.Instances;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Oakton.Descriptions;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Tests.Descriptions
+{
+    [Collection("SetConsoleOutput")]
+    public class ConfigurationPreviewTests
+    {
+        [Fact]
+        public async Task write_configuration_value_with_bracket_to_console()
+        {
+            // Arrange
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "NoBracketKey", "hello world" },
+                { "BracketKey", "value with bracket [hello]" }
+            });
+            var config = configBuilder.Build();
+
+            
+            var original = Console.Out;
+            var output = new StringWriter();
+            Console.SetOut(output);
+
+            try
+            {
+                // Act
+                var preview = new ConfigurationPreview(config);
+                await preview.WriteToConsole();
+
+
+                // Assert
+                var text = output.ToString().ReadLines();
+
+                text.ShouldContain(x => x.Contains("hello world"));
+                text.ShouldContain(x => x.Contains("value with bracket [hello]"));
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+        }
+    }
+}


### PR DESCRIPTION
fix: avoid throwing exception from ConfigurationPreview when configuration value contains "[" (bracket)