### PR TITLE
Graceful shutdown on SIGTERM, closes #79

### DIFF
--- a/src/Oakton/Commands/RunCommand.cs
+++ b/src/Oakton/Commands/RunCommand.cs
@@ -2,6 +2,10 @@ using System;
 using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 using Oakton.Environment;
 
 namespace Oakton.Commands;
@@ -33,6 +37,9 @@ public class RunCommand : OaktonAsyncCommand<RunInput>
             reset.Set();
             eventArgs.Cancel = true;
         });
+
+        var lifetime = host.Services.GetService<IHostApplicationLifetime>();
+        lifetime?.ApplicationStopping.Register(() => reset.Set());
 
         await host.StartAsync();
         reset.Wait();


### PR DESCRIPTION
Just a suggestion, works for me with .NET 7 and a web app. Will be interesting to see if this breaks the build.

docker shuts down containers by sending `SIGTERM` by default. After a timeout, `SIGKILL` kills the container. This is always the case if #79 remains unfixed.