### PR TITLE
Fix: broken license link

### DIFF
--- a/src/Oakton/Oakton.csproj
+++ b/src/Oakton/Oakton.csproj
@@ -11,7 +11,7 @@
         <PackageId>Oakton</PackageId>
         <PackageTags>Command Line Parsing</PackageTags>
         <PackageProjectUrl>https://jasperfx.github.io/oakton</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/jasperfx/oakton/raw/master/LICENSE.TXT</PackageLicenseUrl>
+        <PackageLicenseUrl>https://github.com/jasperfx/oakton/raw/master/LICENSE</PackageLicenseUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>git://github.com/jasperfx/oakton</RepositoryUrl>
         <PackageIcon>jasper-icon.png</PackageIcon>


### PR DESCRIPTION
The license link presented at nuget.org is broken.