### PR TITLE
Allow configuration of custom command creator

### DIFF
--- a/src/Oakton/CommandLineHostingExtensions.cs
+++ b/src/Oakton/CommandLineHostingExtensions.cs
@@ -36,12 +36,41 @@ public static class CommandLineHostingExtensions
     /// <param name="builder"></param>
     /// <param name="args"></param>
     /// <param name="optionsFile">Optionally configure an expected "opts" file</param>
+    /// <returns></returns>
+    public static Task<int> RunOaktonCommands(this IHostBuilder builder, string[] args, string? optionsFile = null)
+    {
+        return execute(builder, Assembly.GetEntryAssembly(), args, optionsFile, null);
+    }
+
+    /// <summary>
+    ///     Execute the extended Oakton command line support for your configured WebHostBuilder.
+    ///     This method would be called within the Task&lt;int&gt; Program.Main(string[] args) method
+    ///     of your AspNetCore application
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="args"></param>
+    /// <param name="optionsFile">Optionally configure an expected "opts" file</param>
     /// <param name="commandCreator">Optionally configure a custom ICommandCreator</param>
     /// <returns></returns>
-    public static Task<int> RunOaktonCommands(this IHostBuilder builder, string[] args, string? optionsFile = null,
-        ICommandCreator? commandCreator = null)
+    public static Task<int> RunOaktonCommands(this IHostBuilder builder, string[] args,
+        ICommandCreator commandCreator, string? optionsFile = null)
     {
         return execute(builder, Assembly.GetEntryAssembly(), args, optionsFile, commandCreator);
+    }
+
+    /// <summary>
+    ///     Execute the extended Oakton command line support for your configured WebHostBuilder.
+    ///     This method would be called within the Task&lt;int&gt; Program.Main(string[] args) method
+    ///     of your AspNetCore application
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="args"></param>
+    /// <param name="optionsFile">Optionally configure an expected "opts" file</param>
+    /// <returns></returns>
+    public static int RunOaktonCommandsSynchronously(this IHostBuilder builder, string[] args,
+        string? optionsFile = null)
+    {
+        return execute(builder, Assembly.GetEntryAssembly(), args, optionsFile, null).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -55,7 +84,7 @@ public static class CommandLineHostingExtensions
     /// <param name="commandCreator">Optionally configure a custom ICommandCreator</param>
     /// <returns></returns>
     public static int RunOaktonCommandsSynchronously(this IHostBuilder builder, string[] args,
-        string? optionsFile = null, ICommandCreator? commandCreator = null)
+        ICommandCreator commandCreator, string? optionsFile = null)
     {
         return execute(builder, Assembly.GetEntryAssembly(), args, optionsFile, commandCreator).GetAwaiter().GetResult();
     }
@@ -68,12 +97,41 @@ public static class CommandLineHostingExtensions
     /// <param name="host">An already built IHost</param>
     /// <param name="args"></param>
     /// <param name="optionsFile">Optionally configure an expected "opts" file</param>
+    /// <returns></returns>
+    public static Task<int> RunOaktonCommands(this IHost host, string[] args, string? optionsFile = null)
+    {
+        return execute(new PreBuiltHostBuilder(host), Assembly.GetEntryAssembly(), args, optionsFile, null);
+    }
+
+    /// <summary>
+    ///     Execute the extended Oakton command line support for your configured IHost.
+    ///     This method would be called within the Task&lt;int&gt; Program.Main(string[] args) method
+    ///     of your AspNetCore application. This usage is appropriate for WebApplication bootstrapping
+    /// </summary>
+    /// <param name="host">An already built IHost</param>
+    /// <param name="args"></param>
+    /// <param name="optionsFile">Optionally configure an expected "opts" file</param>
     /// <param name="commandCreator">Optionally configure a custom ICommandCreator</param>
     /// <returns></returns>
-    public static Task<int> RunOaktonCommands(this IHost host, string[] args, string? optionsFile = null,
-        ICommandCreator? commandCreator = null)
+    public static Task<int> RunOaktonCommands(this IHost host, string[] args,
+        ICommandCreator commandCreator, string? optionsFile = null)
     {
         return execute(new PreBuiltHostBuilder(host), Assembly.GetEntryAssembly(), args, optionsFile, commandCreator);
+    }
+
+    /// <summary>
+    ///     Execute the extended Oakton command line support for your configured IHost.
+    ///     This method would be called within the Task&lt;int&gt; Program.Main(string[] args) method
+    ///     of your AspNetCore application. This usage is appropriate for WebApplication bootstrapping
+    /// </summary>
+    /// <param name="host">An already built IHost</param>
+    /// <param name="args"></param>
+    /// <param name="optionsFile">Optionally configure an expected "opts" file</param>
+    /// <returns></returns>
+    public static int RunOaktonCommandsSynchronously(this IHost host, string[] args, string? optionsFile = null)
+    {
+        return execute(new PreBuiltHostBuilder(host), Assembly.GetEntryAssembly(), args, optionsFile, null).GetAwaiter()
+            .GetResult();
     }
 
     /// <summary>

--- a/src/Tests/CommandLineExtensionsTester.cs
+++ b/src/Tests/CommandLineExtensionsTester.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Oakton;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+[assembly: OaktonCommandAssembly]
+
+namespace Tests;
+
+public class CommandLineExtensionsTester
+{
+    [Fact]
+    public async Task CanInjectServicesIntoCommands()
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<TestDependency>();
+                services.AddSingleton<TestDICommand>();
+            });
+
+        var app = builder.Build();
+
+        await app.RunOaktonCommands(new[] { "TestDI" }, new DICommandCreator(app.Services));
+
+        Assert.Equal(1, TestDICommand.Value);
+    }
+
+    public class TestInput
+    {
+    }
+
+    public record TestDependency(int Value = 1);
+
+    public class TestDICommand : OaktonCommand<TestInput>
+    {
+        public static int Value { get; set; } = 0;
+        public TestDICommand(TestDependency dep)
+        {
+            Value = dep.Value;
+        }
+
+        public override bool Execute(TestInput input)
+        {
+            return true;
+        }
+    }
+
+    public class DICommandCreator : ICommandCreator
+    {
+        private readonly IServiceProvider _serviceProvider;
+        public DICommandCreator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IOaktonCommand CreateCommand(Type commandType)
+        {
+            var scope = _serviceProvider.CreateScope();
+            return (IOaktonCommand)scope.ServiceProvider.GetRequiredService(commandType);
+        }
+
+        public object CreateModel(Type modelType)
+        {
+            return Activator.CreateInstance(modelType)!;
+        }
+    }
+}


### PR DESCRIPTION
Allow specifying an optional custom command creator when using the IHost & IHostBuilder extension methods.
