### PR TITLE
Fix DI scope disposal and support for overridding the default command

### DIFF
--- a/src/Oakton/DependencyInjectionCommandCreator.cs
+++ b/src/Oakton/DependencyInjectionCommandCreator.cs
@@ -13,8 +13,7 @@ internal class DependencyInjectionCommandCreator : ICommandCreator
 
     public IOaktonCommand CreateCommand(Type commandType)
     {
-        using var scope = _serviceProvider.CreateScope();
-        return ActivatorUtilities.CreateInstance(scope.ServiceProvider, commandType) as IOaktonCommand;
+        return ActivatorUtilities.CreateInstance(_serviceProvider, commandType) as IOaktonCommand;
     }
 
     public object CreateModel(Type modelType)

--- a/src/Oakton/DependencyInjectionCommandCreator.cs
+++ b/src/Oakton/DependencyInjectionCommandCreator.cs
@@ -13,8 +13,8 @@ internal class DependencyInjectionCommandCreator : ICommandCreator
 
     public IOaktonCommand CreateCommand(Type commandType)
     {
-        var scope = _serviceProvider.CreateScope();
-        return (IOaktonCommand)scope.ServiceProvider.GetRequiredService(commandType);
+        using var scope = _serviceProvider.CreateScope();
+        return ActivatorUtilities.CreateInstance(scope.ServiceProvider, commandType) as IOaktonCommand;
     }
 
     public object CreateModel(Type modelType)

--- a/src/Oakton/HostedCommandOptions.cs
+++ b/src/Oakton/HostedCommandOptions.cs
@@ -1,6 +1,0 @@
-﻿namespace Oakton;
-
-public class HostedCommandOptions
-{
-    public string OptionsFile { get; }
-}

--- a/src/Oakton/OaktonOptions.cs
+++ b/src/Oakton/OaktonOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Oakton;
+
+public class OaktonOptions
+{
+    public string OptionsFile { get; set; }
+    public Action<CommandFactory> Factory { get; set; }
+    public string DefaultCommand { get; set; } = "run";
+}

--- a/src/Tests/HostedCommandsTester.cs
+++ b/src/Tests/HostedCommandsTester.cs
@@ -14,7 +14,7 @@ public class HostedCommandsTester
         var builder = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
-                services.AddSingleton<TestDependency>();
+                services.AddScoped<TestDependency>();
                 services.AddOakton(options =>
                 {
                     options.Factory = factory =>
@@ -36,9 +36,23 @@ public class HostedCommandsTester
     {
     }
 
-    public record TestDependency(int Value = 1);
+    public class TestDependency : IDisposable
+    {
+        public int Value { get; private set; }
 
-    public class TestDICommand : OaktonCommand<TestInput>, IDisposable
+        public TestDependency()
+        {
+            Value = 1;
+        }
+
+        public void Dispose()
+        {
+            Value = 0;
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    public class TestDICommand : OaktonCommand<TestInput>
     {
         public static int Value { get; set; } = 0;
         private readonly TestDependency _dep;
@@ -51,12 +65,6 @@ public class HostedCommandsTester
         {
             Value = _dep.Value;
             return true;
-        }
-
-        public void Dispose()
-        {
-            Value = 0;
-            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
refactor(DependencyInjectionCommandCreator): use ActivatorUtilities for command creation

refactor(HostedCommandExtensions): simplify Oakton registration and command execution

feat(HostedCommandExtensions): add OaktonOptions for configuration

refactor(HostedCommandExtensions): remove HostedCommandOptions in favor of OaktonOptions

test(HostedCommandsTester): update tests to use OaktonOptions and default command