### PR TITLE
Use DisposeAsync with scopes and hosts

### DIFF
--- a/src/Oakton/DependencyInjectionCommandCreator.cs
+++ b/src/Oakton/DependencyInjectionCommandCreator.cs
@@ -34,12 +34,12 @@ internal class DependencyInjectionCommandCreator : ICommandCreator
 
 internal class WrappedOaktonCommand : IOaktonCommand
 {
-    private readonly IServiceScope _scope;
+    private readonly AsyncServiceScope _scope;
     private readonly IOaktonCommand _inner;
 
     public WrappedOaktonCommand(IServiceProvider provider, Type commandType)
     {
-        _scope = provider.CreateScope();
+        _scope = provider.CreateAsyncScope();
         _inner = (IOaktonCommand)_scope.ServiceProvider.GetRequiredService(commandType);
     }
 
@@ -47,15 +47,10 @@ internal class WrappedOaktonCommand : IOaktonCommand
     public UsageGraph Usages => _inner.Usages;
     public async Task<bool> Execute(object input)
     {
-        try
+        await using (_scope)
         {
             // Execute your actual command
             return await _inner.Execute(input);
-        }
-        finally
-        {
-            // Make sure the entire scope is disposed
-            _scope.SafeDispose();
         }
     }
 }

--- a/src/Oakton/HostedCommandExtensions.cs
+++ b/src/Oakton/HostedCommandExtensions.cs
@@ -64,7 +64,7 @@ public static class HostedCommandExtensions
     {
         try
         {
-            using var scope = host.Services.CreateScope();
+            await using var scope = host.Services.CreateAsyncScope();
             var options = scope.ServiceProvider.GetRequiredService<IOptions<OaktonOptions>>().Value;
             args = ApplyArgumentDefaults(args, options);
 
@@ -88,7 +88,14 @@ public static class HostedCommandExtensions
         }
         finally
         {
-            host.SafeDispose();
+            if (host is IAsyncDisposable ad)
+            {
+                await ad.DisposeAsync();
+            }
+            else
+            {
+                host.Dispose();
+            }
         }
     }
 


### PR DESCRIPTION
This is about using async where it's available.

Some of the changed places used `SafeDispose()` earlier. Not sure how important that was, but it wasn't used consistently.