### PR TITLE
Add documentation for OaktonEnvironment.AutoStart in unit tests

### DIFF
--- a/docs/guide/host/integration_with_i_host.md
+++ b/docs/guide/host/integration_with_i_host.md
@@ -114,3 +114,12 @@ There are just a couple things to note:
 
 If you're having any issues with Serilog logging while using Oakton, please see this [StackOverflow issue](https://stackoverflow.com/questions/55422528/logging-with-serilog-net-core-not-outputting).
 
+
+## Using Oakton with WebApplicationFactory or Alba
+
+When running integration tests against a `WebApplication` using `WebApplicationFactory` or `Alba`, you may encounter an issue where the server does not start. To fix this, set the following property before creating the `WebApplicationFactory`.
+
+```cs
+OaktonEnvironment.AutoStart = true;
+```
+

--- a/docs/guide/host/integration_with_i_host.md
+++ b/docs/guide/host/integration_with_i_host.md
@@ -120,6 +120,6 @@ If you're having any issues with Serilog logging while using Oakton, please see 
 When running integration tests against a `WebApplication` using `WebApplicationFactory` or `Alba`, you may encounter an issue where the server does not start. To fix this, set the following property before creating the `WebApplicationFactory`.
 
 ```cs
-OaktonEnvironment.AutoStart = true;
+OaktonEnvironment.AutoStartHost = true;
 ```
 


### PR DESCRIPTION
Since this was not documented anywhere, I thought I could not use Oakton with WebApplicationFactory.