### PR TITLE
Enable nullable reference types in Oakton project

### DIFF
--- a/src/Oakton/ActivatorCommandCreator.cs
+++ b/src/Oakton/ActivatorCommandCreator.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class ActivatorCommandCreator : ICommandCreator
 {
     public IOaktonCommand CreateCommand(Type commandType)

--- a/src/Oakton/Argument.cs
+++ b/src/Oakton/Argument.cs
@@ -8,6 +8,8 @@ using Oakton.Parsing;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class Argument : TokenHandlerBase
 {
     private readonly MemberInfo _member;

--- a/src/Oakton/AssemblyInfo.cs
+++ b/src/Oakton/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
+#nullable disable annotations // FIXME
+
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/Oakton/AssemblyInfo.cs
+++ b/src/Oakton/AssemblyInfo.cs
@@ -1,5 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 
-#nullable disable annotations // FIXME
-
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/Oakton/CommandExecutor.cs
+++ b/src/Oakton/CommandExecutor.cs
@@ -9,6 +9,8 @@ using Spectre.Console;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     The main entry class for Oakton command line applications
 /// </summary>

--- a/src/Oakton/CommandFactory.cs
+++ b/src/Oakton/CommandFactory.cs
@@ -14,6 +14,8 @@ using System.Text.RegularExpressions;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class CommandFactory : ICommandFactory
 {
     private static readonly string[] _helpCommands = { "help", "?" };

--- a/src/Oakton/CommandFailureException.cs
+++ b/src/Oakton/CommandFailureException.cs
@@ -2,6 +2,8 @@ using System;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class CommandFailureException : Exception
 {
     public CommandFailureException(string message) : base(message)

--- a/src/Oakton/CommandLineHostingExtensions.cs
+++ b/src/Oakton/CommandLineHostingExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
 using Oakton.Commands;

--- a/src/Oakton/CommandRun.cs
+++ b/src/Oakton/CommandRun.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class CommandRun
 {
     public IOaktonCommand Command { get; set; }

--- a/src/Oakton/Commands/CheckEnvironmentCommand.cs
+++ b/src/Oakton/Commands/CheckEnvironmentCommand.cs
@@ -7,6 +7,8 @@ using Spectre.Console;
 
 namespace Oakton.Commands;
 
+#nullable disable annotations // FIXME
+
 public class CheckEnvironmentInput : NetCoreInput
 {
     [Description("Use to optionally write the results of the environment checks to a file")]

--- a/src/Oakton/Commands/RunCommand.cs
+++ b/src/Oakton/Commands/RunCommand.cs
@@ -10,6 +10,8 @@ using Oakton.Environment;
 
 namespace Oakton.Commands;
 
+#nullable disable annotations // FIXME
+
 public class RunInput : NetCoreInput
 {
     [Description("Run the environment checks before starting the host")]

--- a/src/Oakton/DependencyInjectionCommandCreator.cs
+++ b/src/Oakton/DependencyInjectionCommandCreator.cs
@@ -8,6 +8,8 @@ using Oakton.Help;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 internal class DependencyInjectionCommandCreator : ICommandCreator
 {
     private readonly IServiceProvider _serviceProvider;

--- a/src/Oakton/DescriptionAttribute.cs
+++ b/src/Oakton/DescriptionAttribute.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Adds a textual description to arguments or flags on input classes, or on a command class
 /// </summary>

--- a/src/Oakton/Descriptions/ConfigurationPreview.cs
+++ b/src/Oakton/Descriptions/ConfigurationPreview.cs
@@ -6,6 +6,8 @@ using Spectre.Console;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 internal class ConfigurationPreview : IDescribedSystemPart, IWriteToConsole
 {
     private const string PreviewErrorMessage = "Unable to show a preview of the configuration.";

--- a/src/Oakton/Descriptions/DescribeCommand.cs
+++ b/src/Oakton/Descriptions/DescribeCommand.cs
@@ -11,6 +11,8 @@ using Spectre.Console;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 [Description("Writes out a description of your running application to either the console or a file")]
 public class DescribeCommand : OaktonAsyncCommand<DescribeInput>
 {

--- a/src/Oakton/Descriptions/DescribeInput.cs
+++ b/src/Oakton/Descriptions/DescribeInput.cs
@@ -1,5 +1,7 @@
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 public class DescribeInput : NetCoreInput
 {
     [Description("Optionally write the description to the given file location")]

--- a/src/Oakton/Descriptions/DescriptionExtensions.cs
+++ b/src/Oakton/Descriptions/DescriptionExtensions.cs
@@ -7,6 +7,8 @@ using Spectre.Console;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 public static class DescriptionExtensions
 {
     /// <summary>

--- a/src/Oakton/Descriptions/IDescribedSystemPart.cs
+++ b/src/Oakton/Descriptions/IDescribedSystemPart.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 #region sample_IDescribedSystemPart
 
 /// <summary>

--- a/src/Oakton/Descriptions/IDescribedSystemPartFactory.cs
+++ b/src/Oakton/Descriptions/IDescribedSystemPartFactory.cs
@@ -1,5 +1,7 @@
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 #region sample_IDescribedSystemPartFactory
 
 /// <summary>

--- a/src/Oakton/Descriptions/IDescribesProperties.cs
+++ b/src/Oakton/Descriptions/IDescribesProperties.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Interface to expose key/value pairs to diagnostic output
 /// </summary>

--- a/src/Oakton/Descriptions/IRequiresServices.cs
+++ b/src/Oakton/Descriptions/IRequiresServices.cs
@@ -2,6 +2,8 @@ using System;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 internal interface IRequiresServices
 {
     void Resolve(IServiceProvider services);

--- a/src/Oakton/Descriptions/ITreeDescriber.cs
+++ b/src/Oakton/Descriptions/ITreeDescriber.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Interface to expose additional diagnostic information to a Spectre tree node
 /// </summary>

--- a/src/Oakton/Descriptions/IWriteToConsole.cs
+++ b/src/Oakton/Descriptions/IWriteToConsole.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Optional interface for exposing specialized console output
 ///     in the "describe" command

--- a/src/Oakton/Descriptions/LambdaDescribedSystemPart.cs
+++ b/src/Oakton/Descriptions/LambdaDescribedSystemPart.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Oakton.Descriptions;
 
+#nullable disable annotations // FIXME
+
 internal class LambdaDescribedSystemPart<T> : IDescribedSystemPart, IRequiresServices
 {
     private readonly Func<T, TextWriter, Task> _write;

--- a/src/Oakton/Environment/EnvironmentCheckException.cs
+++ b/src/Oakton/Environment/EnvironmentCheckException.cs
@@ -3,6 +3,8 @@ using System.Linq;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 public class EnvironmentCheckException : AggregateException
 {
     public EnvironmentCheckException(EnvironmentCheckResults results) : base(results.ToString(),

--- a/src/Oakton/Environment/EnvironmentCheckExtensions.cs
+++ b/src/Oakton/Environment/EnvironmentCheckExtensions.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 public static class EnvironmentCheckExtensions
 {
     /// <summary>

--- a/src/Oakton/Environment/EnvironmentCheckResults.cs
+++ b/src/Oakton/Environment/EnvironmentCheckResults.cs
@@ -6,6 +6,8 @@ using JasperFx.Core;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 public class EnvironmentCheckResults
 {
     private readonly IList<EnvironmentFailure> _failures = new List<EnvironmentFailure>();

--- a/src/Oakton/Environment/EnvironmentChecker.cs
+++ b/src/Oakton/Environment/EnvironmentChecker.cs
@@ -9,6 +9,8 @@ using Spectre.Console;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Executes the environment checks registered in an IoC container
 /// </summary>

--- a/src/Oakton/Environment/FileExistsCheck.cs
+++ b/src/Oakton/Environment/FileExistsCheck.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 public class FileExistsCheck : IEnvironmentCheck
 {
     private readonly string _file;

--- a/src/Oakton/Environment/IEnvironmentCheck.cs
+++ b/src/Oakton/Environment/IEnvironmentCheck.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 #region sample_IEnvironmentCheck
 
 /// <summary>

--- a/src/Oakton/Environment/IEnvironmentCheckFactory.cs
+++ b/src/Oakton/Environment/IEnvironmentCheckFactory.cs
@@ -1,5 +1,7 @@
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 public interface IEnvironmentCheckFactory
 {
     IEnvironmentCheck[] Build();

--- a/src/Oakton/Environment/LambdaCheck.cs
+++ b/src/Oakton/Environment/LambdaCheck.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 namespace Oakton.Environment;
 
+#nullable disable annotations // FIXME
+
 public class LambdaCheck : IEnvironmentCheck
 {
     private readonly Func<IServiceProvider, CancellationToken, Task> _action;

--- a/src/Oakton/FlagAliasAttribute.cs
+++ b/src/Oakton/FlagAliasAttribute.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Use to override the long and/or short flag keys of a property or field
 /// </summary>

--- a/src/Oakton/Help/CommandUsage.cs
+++ b/src/Oakton/Help/CommandUsage.cs
@@ -6,6 +6,8 @@ using Spectre.Console;
 
 namespace Oakton.Help;
 
+#nullable disable annotations // FIXME
+
 public class CommandUsage
 {
     public string Description { get; set; }

--- a/src/Oakton/Help/HelpCommand.cs
+++ b/src/Oakton/Help/HelpCommand.cs
@@ -4,6 +4,8 @@ using Spectre.Console;
 
 namespace Oakton.Help;
 
+#nullable disable annotations // FIXME
+
 [Description("List all the available commands", Name = "help")]
 public class HelpCommand : OaktonCommand<HelpInput>
 {

--- a/src/Oakton/Help/HelpInput.cs
+++ b/src/Oakton/Help/HelpInput.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 
 namespace Oakton.Help;
 
+#nullable disable annotations // FIXME
+
 public class HelpInput
 {
     [IgnoreOnCommandLine] public IEnumerable<Type> CommandTypes { get; set; }

--- a/src/Oakton/Help/UsageGraph.cs
+++ b/src/Oakton/Help/UsageGraph.cs
@@ -10,6 +10,8 @@ using Spectre.Console;
 
 namespace Oakton.Help;
 
+#nullable disable annotations // FIXME
+
 public class UsageGraph
 {
     private readonly List<ITokenHandler> _handlers;

--- a/src/Oakton/HostWrapperCommand.cs
+++ b/src/Oakton/HostWrapperCommand.cs
@@ -7,6 +7,8 @@ using Oakton.Help;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 internal class HostWrapperCommand : IOaktonCommand
 {
     private readonly IOaktonCommand _inner;

--- a/src/Oakton/HostedCommandExtensions.cs
+++ b/src/Oakton/HostedCommandExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using JasperFx.Core;
+﻿using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;

--- a/src/Oakton/ICommandCreator.cs
+++ b/src/Oakton/ICommandCreator.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Service locator for command types. The default just uses Activator.CreateInstance().
 ///     Can be used to plug in IoC construction in Oakton applications

--- a/src/Oakton/ICommandFactory.cs
+++ b/src/Oakton/ICommandFactory.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Hosting;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Interface that Oakton uses to build command runs during execution. Can be used for custom
 ///     command activation

--- a/src/Oakton/IHostBuilderInput.cs
+++ b/src/Oakton/IHostBuilderInput.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Interface used to get access to the HostBuilder from command inputs.
 /// </summary>

--- a/src/Oakton/IOaktonCommand.cs
+++ b/src/Oakton/IOaktonCommand.cs
@@ -4,6 +4,8 @@ using Oakton.Help;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public interface IOaktonCommand
 {
     Type InputType { get; }

--- a/src/Oakton/IServiceRegistrations.cs
+++ b/src/Oakton/IServiceRegistrations.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Implementations of this interface can be used to define
 ///     service registrations to be loaded by Oakton command extensions

--- a/src/Oakton/IgnoreOnCommandLineAttribute.cs
+++ b/src/Oakton/IgnoreOnCommandLineAttribute.cs
@@ -2,8 +2,6 @@
 
 namespace Oakton;
 
-#nullable disable annotations // FIXME
-
 /// <summary>
 ///     Oakton ignores any fields or properties with this attribute during the binding to the input
 ///     objects

--- a/src/Oakton/IgnoreOnCommandLineAttribute.cs
+++ b/src/Oakton/IgnoreOnCommandLineAttribute.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Oakton ignores any fields or properties with this attribute during the binding to the input
 ///     objects

--- a/src/Oakton/InjectServiceAttribute.cs
+++ b/src/Oakton/InjectServiceAttribute.cs
@@ -2,6 +2,8 @@ using System;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 /// Decorate Oakton commands that are being called by 
 /// </summary>

--- a/src/Oakton/InjectServiceAttribute.cs
+++ b/src/Oakton/InjectServiceAttribute.cs
@@ -2,8 +2,6 @@ using System;
 
 namespace Oakton;
 
-#nullable disable annotations // FIXME
-
 /// <summary>
 /// Decorate Oakton commands that are being called by 
 /// </summary>

--- a/src/Oakton/Internal/ArgsExtensions.cs
+++ b/src/Oakton/Internal/ArgsExtensions.cs
@@ -2,6 +2,8 @@ using System.Linq;
 
 namespace Oakton.Internal;
 
+#nullable disable annotations // FIXME
+
 public static class ArgsExtensions
 {
     public static string[] FilterLauncherArgs(this string[] args)

--- a/src/Oakton/Internal/Conversion/Conversions.cs
+++ b/src/Oakton/Internal/Conversion/Conversions.cs
@@ -7,9 +7,10 @@ namespace Oakton.Internal.Conversion;
 
 public class Conversions
 {
+#nullable disable annotations // FIXME
     private readonly LightweightCache<Type, Func<string, object>> _convertors;
     private readonly IList<IConversionProvider> _providers = new List<IConversionProvider>();
-
+#nullable restore
 
     public Conversions()
     {

--- a/src/Oakton/Internal/Conversion/DateTimeConverter.cs
+++ b/src/Oakton/Internal/Conversion/DateTimeConverter.cs
@@ -5,6 +5,8 @@ using System.Text.RegularExpressions;
 
 namespace Oakton.Internal.Conversion;
 
+#nullable disable annotations // FIXME
+
 public class DateTimeConverter
 {
     public const string TODAY = "TODAY";

--- a/src/Oakton/Internal/Conversion/TimeSpanConverter.cs
+++ b/src/Oakton/Internal/Conversion/TimeSpanConverter.cs
@@ -4,6 +4,8 @@ using System.Text.RegularExpressions;
 
 namespace Oakton.Internal.Conversion;
 
+#nullable disable annotations // FIXME
+
 public class TimeSpanConverter
 {
     private const string TimespanPattern =

--- a/src/Oakton/InvalidUsageException.cs
+++ b/src/Oakton/InvalidUsageException.cs
@@ -2,6 +2,8 @@ using System;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class InvalidUsageException : Exception
 {
     public InvalidUsageException() : base(string.Empty)

--- a/src/Oakton/NetCoreInput.cs
+++ b/src/Oakton/NetCoreInput.cs
@@ -11,6 +11,8 @@ using Spectre.Console;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class NetCoreInput : IHostBuilderInput
 {
     [Description("Overwrite individual configuration items")]

--- a/src/Oakton/Oakton.csproj
+++ b/src/Oakton/Oakton.csproj
@@ -8,6 +8,7 @@
         <DebugType>portable</DebugType>
         <AssemblyName>Oakton</AssemblyName>
         <LangVersion>11.0</LangVersion>
+        <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <PackageId>Oakton</PackageId>
         <PackageTags>Command Line Parsing</PackageTags>

--- a/src/Oakton/OaktonAsyncCommand.cs
+++ b/src/Oakton/OaktonAsyncCommand.cs
@@ -4,6 +4,8 @@ using Oakton.Help;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Base class for all Oakton commands
 /// </summary>

--- a/src/Oakton/OaktonCommand.cs
+++ b/src/Oakton/OaktonCommand.cs
@@ -4,6 +4,8 @@ using Oakton.Help;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Base class for all Oakton commands
 /// </summary>

--- a/src/Oakton/OaktonCommandAssemblyAttribute.cs
+++ b/src/Oakton/OaktonCommandAssemblyAttribute.cs
@@ -3,6 +3,8 @@ using JasperFx.Core.Reflection;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     If the CommandExecutor is configured to discover assemblies,
 ///     this attribute on an assembly will cause Oakton to search for

--- a/src/Oakton/OaktonEnvironment.cs
+++ b/src/Oakton/OaktonEnvironment.cs
@@ -1,5 +1,7 @@
 ﻿namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public static class OaktonEnvironment
 {
     /// <summary>

--- a/src/Oakton/OaktonEnvironment.cs
+++ b/src/Oakton/OaktonEnvironment.cs
@@ -1,7 +1,5 @@
 ﻿namespace Oakton;
 
-#nullable disable annotations // FIXME
-
 public static class OaktonEnvironment
 {
     /// <summary>

--- a/src/Oakton/OaktonOptions.cs
+++ b/src/Oakton/OaktonOptions.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 public class OaktonOptions
 {
     public string OptionsFile { get; set; }

--- a/src/Oakton/Parsing/ArgPreprocessor.cs
+++ b/src/Oakton/Parsing/ArgPreprocessor.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class ArgPreprocessor
 {
     public static IEnumerable<string> Process(IEnumerable<string> incomingArgs)

--- a/src/Oakton/Parsing/BooleanFlag.cs
+++ b/src/Oakton/Parsing/BooleanFlag.cs
@@ -3,6 +3,8 @@ using System.Reflection;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class BooleanFlag : TokenHandlerBase
 {
     private readonly MemberInfo _member;

--- a/src/Oakton/Parsing/DictionaryFlag.cs
+++ b/src/Oakton/Parsing/DictionaryFlag.cs
@@ -6,6 +6,8 @@ using JasperFx.Core.Reflection;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class DictionaryFlag : TokenHandlerBase
 {
     private readonly string _prefix;

--- a/src/Oakton/Parsing/EnumerableArgument.cs
+++ b/src/Oakton/Parsing/EnumerableArgument.cs
@@ -7,6 +7,8 @@ using Oakton.Internal.Conversion;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class EnumerableArgument : Argument
 {
     private readonly MemberInfo _member;

--- a/src/Oakton/Parsing/EnumerableFlag.cs
+++ b/src/Oakton/Parsing/EnumerableFlag.cs
@@ -6,6 +6,8 @@ using Oakton.Internal.Conversion;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class EnumerableFlag : Flag
 {
     private readonly MemberInfo _member;

--- a/src/Oakton/Parsing/Flag.cs
+++ b/src/Oakton/Parsing/Flag.cs
@@ -7,6 +7,8 @@ using Oakton.Internal.Conversion;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class Flag : TokenHandlerBase
 {
     private readonly MemberInfo _member;

--- a/src/Oakton/Parsing/FlagAliases.cs
+++ b/src/Oakton/Parsing/FlagAliases.cs
@@ -1,5 +1,7 @@
 ﻿namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class FlagAliases
 {
     public string LongForm { get; set; }

--- a/src/Oakton/Parsing/ITokenHandler.cs
+++ b/src/Oakton/Parsing/ITokenHandler.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public interface ITokenHandler
 {
     string Description { get; }

--- a/src/Oakton/Parsing/InputParser.cs
+++ b/src/Oakton/Parsing/InputParser.cs
@@ -9,6 +9,8 @@ using Oakton.Internal.Conversion;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public static class InputParser
 {
     private static readonly string LONG_FLAG_PREFIX = "--";

--- a/src/Oakton/Parsing/OptionReader.cs
+++ b/src/Oakton/Parsing/OptionReader.cs
@@ -4,6 +4,8 @@ using JasperFx.Core;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public static class OptionReader
 {
     public static string Read(string file)

--- a/src/Oakton/Parsing/QueueExtensions.cs
+++ b/src/Oakton/Parsing/QueueExtensions.cs
@@ -3,6 +3,8 @@ using System.Reflection;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public static class QueueExtensions
 {
     public static bool NextIsFlag(this Queue<string> queue)

--- a/src/Oakton/Parsing/StringTokenizer.cs
+++ b/src/Oakton/Parsing/StringTokenizer.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public static class StringTokenizer
 {
     public static IEnumerable<string> Tokenize(string content)

--- a/src/Oakton/Parsing/TokenHandlerBase.cs
+++ b/src/Oakton/Parsing/TokenHandlerBase.cs
@@ -4,6 +4,8 @@ using JasperFx.Core.Reflection;
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public abstract class TokenHandlerBase : ITokenHandler
 {
     protected TokenHandlerBase(MemberInfo member)

--- a/src/Oakton/Parsing/TokenParser.cs
+++ b/src/Oakton/Parsing/TokenParser.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton.Parsing;
 
+#nullable disable annotations // FIXME
+
 public class TokenParser
 {
     private readonly List<string> _tokens = new();

--- a/src/Oakton/PreBuiltHostBuilder.cs
+++ b/src/Oakton/PreBuiltHostBuilder.cs
@@ -7,6 +7,8 @@ using Spectre.Console;
 
 namespace Oakton;
 
+#nullable disable annotations // FIXME
+
 internal class PreBuiltHostBuilder : IHostBuilder
 {
     private readonly string _notSupportedMessage;

--- a/src/Oakton/Resources/IStatefulResource.cs
+++ b/src/Oakton/Resources/IStatefulResource.cs
@@ -5,6 +5,8 @@ using Spectre.Console.Rendering;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 #region sample_IStatefulResourceWithDependencies
 
 /// <summary>

--- a/src/Oakton/Resources/IStatefulResourceSource.cs
+++ b/src/Oakton/Resources/IStatefulResourceSource.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 #region sample_IStatefulResourceSource
 
 /// <summary>

--- a/src/Oakton/Resources/ResourceAction.cs
+++ b/src/Oakton/Resources/ResourceAction.cs
@@ -1,5 +1,7 @@
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 public enum ResourceAction
 {
     clear,

--- a/src/Oakton/Resources/ResourceAction.cs
+++ b/src/Oakton/Resources/ResourceAction.cs
@@ -1,7 +1,5 @@
 namespace Oakton.Resources;
 
-#nullable disable annotations // FIXME
-
 public enum ResourceAction
 {
     clear,

--- a/src/Oakton/Resources/ResourceEnvironmentCheck.cs
+++ b/src/Oakton/Resources/ResourceEnvironmentCheck.cs
@@ -5,6 +5,8 @@ using Oakton.Environment;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 internal class ResourceEnvironmentCheck : IEnvironmentCheck
 {
     private readonly IStatefulResource _resource;

--- a/src/Oakton/Resources/ResourceHostExtensions.cs
+++ b/src/Oakton/Resources/ResourceHostExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Hosting;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 public enum StartupAction
 {
     /// <summary>

--- a/src/Oakton/Resources/ResourceInput.cs
+++ b/src/Oakton/Resources/ResourceInput.cs
@@ -3,6 +3,8 @@ using System.Threading;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 public class ResourceInput : NetCoreInput
 {
     private readonly Lazy<CancellationTokenSource> _cancellation;

--- a/src/Oakton/Resources/ResourceSetupException.cs
+++ b/src/Oakton/Resources/ResourceSetupException.cs
@@ -2,6 +2,8 @@
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 public class ResourceSetupException : Exception
 {
     public ResourceSetupException(IStatefulResource resource, Exception ex) : base(

--- a/src/Oakton/Resources/ResourceSetupHostService.cs
+++ b/src/Oakton/Resources/ResourceSetupHostService.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 internal class ResourceSetupOptions
 {
     public StartupAction Action { get; set; } = StartupAction.SetupOnly;

--- a/src/Oakton/Resources/ResourcesCommand.cs
+++ b/src/Oakton/Resources/ResourcesCommand.cs
@@ -11,6 +11,8 @@ using Spectre.Console.Rendering;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 [Description("Check, setup, or teardown stateful resources of this system")]
 public class ResourcesCommand : OaktonAsyncCommand<ResourceInput>
 {

--- a/src/Oakton/Resources/StatefulResourceBase.cs
+++ b/src/Oakton/Resources/StatefulResourceBase.cs
@@ -5,6 +5,8 @@ using Spectre.Console.Rendering;
 
 namespace Oakton.Resources;
 
+#nullable disable annotations // FIXME
+
 /// <summary>
 ///     Base class with empty implementations for IStatefulResource.
 /// </summary>


### PR DESCRIPTION
Enable nullable reference types in Oakton project. This enables nullability warnings for the project (a number of them are reported now). Also, it will default newly added files to be nullable-enabled.

Prior nullable-oblivious types are preserved by adding `#nullable disable annotations` to nearly all files (apart from two that had `#nullable enable` pragmas, some files in `Internal.Conversions` that used nullable references in signatures,  and some files where the pragma is clearly redundant).  